### PR TITLE
Small changes for Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/adaptivekde/sshist.py
+++ b/adaptivekde/sshist.py
@@ -30,6 +30,10 @@ def sshist(x, N=range(2, 501), SN=30):
     -------
     optN : int
         Optimal number of bins to represent the data in X
+    optD : double
+        Optimal width of bins
+    edges : array_like
+        Edges of optimized bins
     N : double
         Maximum number of bins to be evaluated. Default value = 500.
     C : array_like

--- a/adaptivekde/sskernel.py
+++ b/adaptivekde/sskernel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def sskernel(x, tin=None, W=None, nbs=1e3):
+def sskernel(x, tin=None, W=None, nbs=1000):
     """
     Generates a kernel density estimate with globally-optimized bandwidth.
 
@@ -60,7 +60,7 @@ def sskernel(x, tin=None, W=None, nbs=1e3):
         T = np.max(x) - np.min(x)
         dx = np.sort(np.diff(np.sort(x)))
         dt_samp = dx[np.nonzero(dx)][0]
-        tin = np.linspace(np.min(x), np.max(x), min(np.ceil(T / dt_samp), 1e3))
+        tin = np.linspace(np.min(x), np.max(x), int(min(np.ceil(T / dt_samp), 1e3)))
         t = tin
         x_ab = x[(x >= min(tin)) & (x <= max(tin))]
     else:
@@ -69,7 +69,7 @@ def sskernel(x, tin=None, W=None, nbs=1e3):
         dx = np.sort(np.diff(np.sort(x)))
         dt_samp = dx[np.nonzero(dx)][0]
         if dt_samp > min(np.diff(tin)):
-            t = np.linspace(min(tin), max(tin), min(np.ceil(T / dt_samp), 1e3))
+            t = np.linspace(min(tin), max(tin), int(min(np.ceil(T / dt_samp), 1e3)))
         else:
             t = tin
 
@@ -179,7 +179,7 @@ def fftkernel(x, w):
 
     X = np.fft.fft(x, n.astype(np.int))
 
-    f = np.linspace(0, n-1, n) / n
+    f = np.linspace(0, n-1, n.astype(np.int)) / n
     f = np.concatenate((-f[0: np.int(n / 2 + 1)],
                         f[1: np.int(n / 2 - 1 + 1)][::-1]))
 

--- a/adaptivekde/ssvkernel.py
+++ b/adaptivekde/ssvkernel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def ssvkernel(x, tin=None, M=80, nbs=1e2, WinFunc='Boxcar'):
+def ssvkernel(x, tin=None, M=80, nbs=100, WinFunc='Boxcar'):
     """
     Generates a locally adaptive kernel-density estimate for one-dimensional
     data.
@@ -76,7 +76,7 @@ def ssvkernel(x, tin=None, M=80, nbs=1e2, WinFunc='Boxcar'):
         T = np.max(x) - np.min(x)
         dx = np.sort(np.diff(np.sort(x)))
         dt_samp = dx[np.nonzero(dx)][0]
-        tin = np.linspace(np.min(x), np.max(x), min(np.ceil(T / dt_samp), 1e3))
+        tin = np.linspace(np.min(x), np.max(x), int(min(np.ceil(T / dt_samp), 1e3)))
         t = tin
         x_ab = x[(x >= min(tin)) & (x <= max(tin))]
     else:
@@ -85,7 +85,7 @@ def ssvkernel(x, tin=None, M=80, nbs=1e2, WinFunc='Boxcar'):
         dx = np.sort(np.diff(np.sort(x)))
         dt_samp = dx[np.nonzero(dx)][0]
         if dt_samp > min(np.diff(tin)):
-            t = np.linspace(min(tin), max(tin), min(np.ceil(T / dt_samp), 1e3))
+            t = np.linspace(min(tin), max(tin), int(min(np.ceil(T / dt_samp), 1e3)))
         else:
             t = tin
 
@@ -241,7 +241,7 @@ def fftkernel(x, w):
     X = np.fft.fft(x, n.astype(np.int))
 
     # generate kernel domain
-    f = np.linspace(0, n-1, n) / n
+    f = np.linspace(0, n-1, n.astype(np.int)) / n
     f = np.concatenate((-f[0: np.int(n / 2 + 1)],
                         f[1: np.int(n / 2 - 1 + 1)][::-1]))
 
@@ -263,7 +263,8 @@ def fftkernelWin(x, w, WinFunc):
     X = np.fft.fft(x, n.astype(np.int))
 
     # generate kernel domain
-    f = np.linspace(0, n-1, n) / n
+
+    f = np.linspace(0, n-1, n.astype(np.int)) / n
     f = np.concatenate((-f[0: np.int(n / 2 + 1)],
                         f[1: np.int(n / 2 - 1 + 1)][::-1]))
     t = 2 * np.pi * f
@@ -321,3 +322,4 @@ def ilogexp(x):
     y[x < 1e2] = np.log(np.exp(x[x < 1e2]) - 1)
     y[x >= 1e2] = x[x >= 1e2]
     return y
+    


### PR DESCRIPTION
This is a minor change for Python 3 compatibility. Should be fully backwards-compatible with Python 2.

Tested ssvkernel, sskernel, and sshist on Python 3.9

Changes:
* `np.linspace` was complaining about non-integer step sizes, so I changed those to `int` or `np.int`. That's it.
* `sshist` returns 5 values but there were only 3 in the docstring, so I added the missing ones. 

Problems:
* This is a separate issue entirely: `ssvkernel` raises a warning about division by zero when using Boxcar and Laplace kernels. I didn't look into this too deeply, but the plotted density in matplotlib looks fine.