### PR TITLE
Fixing the warning issue and correction of the Laplace function

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,7 +13,7 @@ All software in this package is licensed under the Apache License 2.0.
 See LICENSE.txt for more details.
  
 Authors:
-Hideaki Shimazaki (shimazaki@jhu.edu) shimazaki on Github
+Hideaki Shimazaki (shimazaki.hideaki.8x@kyoto-u.jp) shimazaki on Github
 Lee A.D. Cooper (cooperle@gmail.com) cooperlab on GitHub
 Subhasis Ray (ray.subhasis@gmail.com)
  

--- a/adaptivekde/ssvkernel.py
+++ b/adaptivekde/ssvkernel.py
@@ -271,8 +271,9 @@ def fftkernelWin(x, w, WinFunc):
     # determine window function - evaluate kernel
     if WinFunc == 'Boxcar':
         a = 12**0.5 * w
-        K = 2 * np.sin(a * t / 2) / (a * t)
+        K = np.zeros(len(t))
         K[0] = 1
+        K[1:] = 2 * np.sin(a * t[1:] / 2) / (a * t[1:])
     elif WinFunc == 'Laplace':
         K = 1 / (1 + (w * 2 * np.pi * f)**2 / 2)
     elif WinFunc == 'Cauchy':

--- a/adaptivekde/ssvkernel.py
+++ b/adaptivekde/ssvkernel.py
@@ -294,7 +294,7 @@ def Gauss(x, w):
 
 
 def Laplace(x, w):
-    y = 1 / 2**0.5 / w * np.exp(-(2**0.5) / w / np.abs(x))
+    y = 1 / 2**0.5 / w * np.exp(-(2**0.5) / w * np.abs(x))
     return y
 
 


### PR DESCRIPTION
- The warning issue due to division by zero in the Boxcar windows computation was fixed. 
- The Laplace function is corrected.
- An email address in README was updated. 
